### PR TITLE
Suppression des liens éditeur / lecteur

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,9 @@
           <div class="content">
             <h2>L'éditeur <span class="accessimap">accessimap</span></h2>
             <p>L'éditeur <strong>Accessimap</strong> est une <strong>application web</strong> facilitant la <strong>création de dessins en relief interactifs</strong> (DERi). Cela peut être des <strong>cartes</strong> géographiques, avec une récupération automatisée des données provenant de la base OpenStreetMap (routes, passages piétons, ligne de vie, surface podotactile, ...), ou votre dessin préféré,...
-              L'éditeur est utilisé par les transcripteurs (professionnels des instituts spécialisés qui "traduisent" un document en dessin en relief) ou les professeurs directement.</p>
-              <a href="http://makinacorpus.github.io/accessimap-editeur-der/" target="_blank" class="button blue">Accéder à l'éditeur</a>
+              L'éditeur est utilisé par les transcripteurs 
+              (professionnels des instituts spécialisés qui "traduisent" un document en dessin en relief) 
+              ou les professeurs directement.</p>
           </div>
         </section>
 
@@ -44,23 +45,21 @@
           <img class="icon" src="img/icon-read.svg">
           <div class="content">
             <h2>Le lecteur <span class="accessimap">accessimap</span></h2>
-            <p>L'éditeur est aussi couplé à un <strong>lecteur de dessin en relief interactif</strong>. Ce lecteur est multiplateforme, et peut donc être utilisé classiquement sur un PC avec écran tactile, mais aussi sur des tablettes.
+            <p>L'éditeur est aussi couplé à un <strong>lecteur de dessin en relief interactif</strong>. 
+            Ce lecteur est multiplateforme, et peut donc être utilisé classiquement sur un PC avec écran tactile, mais aussi sur des tablettes.
             Grâce au dessin imprimé sur du papier thermogonflable (les traits noirs prennent du relief en passant dans un four et deviennent "lisibles" par les déficients visuels), l'utilisateur bénéficie alors d'indications sonores lors de l'exploration du DERi,
             ce qui lui permet par exemple de mieux comprendre le trajet entre son domicile et la station de métro la plus proche.</p>
-            <p>Le lecteur est encore en cours de développement. Vous pouvez néanmoins déjà tester la version PC.</p>
-            <a href="https://github.com/makinacorpus/accessimap-lecteur-der/releases" target="_blank" class="button red">Télécharger le lecteur</a>
-            <p class="legend">Instructions pour Windows : télécharger la dernière version du fichier zip (<b>accessimap-lecteur-der-x.x.x-win.zip</b>),
-              extraire, ouvrir le dossier win-unpacked, puis exécuter le fichier nommé <b>accessimap-lecteur-der.exe</b></p>
           </div>
         </section>
       </div>
 
       <section class="formulaire bg-paper double-col">
         <div class="row content">
-          <h2>Participez au projet <span class="accessimap">accessimap</span></h2>
+          <h2>Participez au projet <span class="accessimap">accessimap</span>, devenez bêta-testeur !</h2>
           <p><span class="accessimap">accessimap</span> est un projet de recherche, nous avons besoin que les utilisateurs affirment leur intérêt pour le projet. </p>
           <p>Soutenez-le en nous communiquant les informations ci-dessous.
-            Celles-ci ne seront pas diffusées. Vous pourriez éventuellement être contacté pour participer à l'amélioration de l'éditeur et du lecteur.</p>
+            Celles-ci ne seront pas diffusées. 
+            Vous pourriez éventuellement être contacté pour participer à l'amélioration de l'éditeur et du lecteur à travers notre programme de bêta-testeurs.</p>
             <iframe scrolling="no" marginheight="0" marginwidth="0" src="https://app.mailjet.com/widget/iframe/xhH/1NP" height="360"></iframe>
         </div>
         <div class="photo"></div>


### PR DESCRIPTION
Suite à réunion ce jour à Paris à la FAF,
Christophe & Cindy pensent qu'il est prématuré de diffuser les liens vers l'éditeur et le lecteur.

J'ai donc supprimé les liens, et proposé un programme de bêta-testeurs.

Merci de valider la PR (pas de droits sur le repo) plutôt rapidement...